### PR TITLE
fix(navigation): support numeric params

### DIFF
--- a/packages/@wroud/navigation/src/IRouteMatcher.ts
+++ b/packages/@wroud/navigation/src/IRouteMatcher.ts
@@ -1,10 +1,15 @@
 import type { IRouteState } from "./IRouteState.js";
 
 /**
- * Parameter values extracted from URL routes.
- * Can be either a single string value or an array of strings for wildcard routes.
+ * Primitive parameter type supported by the router.
  */
-export type RouteParams = Record<string, string | string[]>;
+export type RouteParamValue = string | number | boolean;
+
+/**
+ * Parameter values extracted from URL routes.
+ * Can be either a single primitive value or an array of primitive values for wildcard routes.
+ */
+export type RouteParams = Record<string, RouteParamValue | RouteParamValue[]>;
 
 export type RouteMatcherState<T extends IRouteMatcher> = Exclude<
   ReturnType<T["match"]>,

--- a/packages/@wroud/navigation/src/pattern-matching/parameter-utils.test.ts
+++ b/packages/@wroud/navigation/src/pattern-matching/parameter-utils.test.ts
@@ -63,6 +63,19 @@ describe("Parameter Utilities", () => {
         );
       }
     });
+
+    test("should allow numeric and boolean parameter values", () => {
+      const pattern = "/item/:id";
+      const segments = ["/", "item", ":id"];
+
+      expect(() =>
+        parameterUtils.validateParameters(pattern, segments, { id: 0 }),
+      ).not.toThrow();
+
+      expect(() =>
+        parameterUtils.validateParameters(pattern, segments, { id: false }),
+      ).not.toThrow();
+    });
   });
 
   describe("buildUrlSegments", () => {
@@ -75,11 +88,26 @@ describe("Parameter Utilities", () => {
       });
       expect(result).toEqual(["user", "123", "profile"]);
 
+      // Numeric and boolean parameters
+      result = parameterUtils.buildUrlSegments(["item", ":id"], { id: 42 });
+      expect(result).toEqual(["item", "42"]);
+
+      result = parameterUtils.buildUrlSegments(["flag", ":active"], { active: false });
+      expect(result).toEqual(["flag", "false"]);
+
       // Wildcard array parameter
       result = parameterUtils.buildUrlSegments(["files", ":path*"], {
         path: ["docs", "reports", "annual.pdf"],
       });
       expect(result).toEqual(["files", "docs", "reports", "annual.pdf"]);
+
+      // Wildcard array with numeric values
+      result = parameterUtils.buildUrlSegments(["ids", ":ids*"], { ids: [1, 2] });
+      expect(result).toEqual(["ids", "1", "2"]);
+
+      // Wildcard array with boolean values
+      result = parameterUtils.buildUrlSegments(["flags", ":flags*"], { flags: [true, false] });
+      expect(result).toEqual(["flags", "true", "false"]);
 
       // Wildcard string parameter
       result = parameterUtils.buildUrlSegments(["files", ":path*"], {

--- a/packages/@wroud/navigation/src/pattern-matching/parameter-utils.ts
+++ b/packages/@wroud/navigation/src/pattern-matching/parameter-utils.ts
@@ -22,7 +22,9 @@ export function validateParameters(
       const value = params[paramName];
       const isWildcard = isWildcardSegment(segment);
 
-      if (!value) {
+      const isMissing = value === undefined || value === null || value === "";
+
+      if (isMissing || (!isWildcard && Array.isArray(value))) {
         if (isWildcard) {
           throw new Error(`Missing required wildcard parameter: ${paramName}`);
         } else {
@@ -30,10 +32,6 @@ export function validateParameters(
             `Missing or invalid required parameter: ${paramName}`,
           );
         }
-      }
-
-      if (!isWildcard && Array.isArray(value)) {
-        throw new Error(`Missing or invalid required parameter: ${paramName}`);
       }
     });
 }
@@ -56,8 +54,13 @@ export function buildUrlSegments(
 
       // Handle wildcard parameters (arrays)
       if (isWildcardSegment(segment) && Array.isArray(value)) {
-        // Filter out undefined values and add valid items
-        return [...result, ...value.filter((item) => item !== undefined)];
+        // Filter out undefined values and add valid items as strings
+        return [
+          ...result,
+          ...value
+            .filter((item) => item !== undefined)
+            .map((item) => String(item)),
+        ];
       }
 
       // Simplify handling of single value parameters

--- a/packages/@wroud/navigation/src/pattern-matching/types.ts
+++ b/packages/@wroud/navigation/src/pattern-matching/types.ts
@@ -2,7 +2,7 @@
  * Types for the Trie-based pattern matching system
  */
 
-import type { RouteParams } from "../IRouteMatcher.js";
+import type { RouteParams, RouteParamValue } from "../IRouteMatcher.js";
 import type { IRouteState } from "../IRouteState.js";
 
 /**
@@ -48,7 +48,9 @@ export type ExtractRouteParams<Pattern extends string> = Pattern extends
         ? Name
         : K extends `:${infer Name}`
           ? Name
-          : never]: K extends `:${string}*` ? string[] : string;
+          : never]: K extends `:${string}*`
+        ? RouteParamValue[]
+        : RouteParamValue;
     };
 
 /**


### PR DESCRIPTION
## Summary
- broaden `RouteParams` and `ExtractRouteParams` to allow boolean and number values
- convert wildcard items to strings when building URLs
- update tests for numeric/boolean parameters

## Testing
- `yarn build`
- `yarn test run`
