### PR TITLE
fix(ci): checkout correct branch for coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - "main"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
 
       - run: corepack enable
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- checkout the correct matrix branch in test workflow so coverage compares with main

## Testing
- `yarn build`
- `yarn test run`
