### PR TITLE
fix(ci): correct coverage workflow path

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -40,4 +40,4 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-compare-path: coverage-main/coverage-summary.json
-          vite-config-path: ${working-directory}/packages/@wroud/tests-runner/vite[st].config.{t|mt|ct|j|mj|cj}s
+          vite-config-path: packages/@wroud/tests-runner/vitest.config.ts


### PR DESCRIPTION
## Summary
- fix `vite-config-path` in coverage report workflow

## Testing
- `yarn build`
- `yarn test run`
