### PR TITLE
test(vite-plugin-ssg): add cleanUrl utility tests

### DIFF
--- a/packages/@wroud/vite-plugin-ssg/src/utils/cleanUrl.test.ts
+++ b/packages/@wroud/vite-plugin-ssg/src/utils/cleanUrl.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { cleanUrl } from "./cleanUrl.js";
+
+describe("cleanUrl", () => {
+  it("removes query strings and fragments", () => {
+    expect(cleanUrl("/foo?bar#baz")).toBe("/foo");
+    expect(cleanUrl("/foo?bar=baz")).toBe("/foo");
+    expect(cleanUrl("/foo#section")).toBe("/foo");
+  });
+
+  it("returns null and undefined unchanged", () => {
+    expect(cleanUrl(null)).toBeNull();
+    expect(cleanUrl(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `cleanUrl` helper in vite-plugin-ssg

## Testing
- `yarn workspace @wroud/vite-plugin-ssg build`
- `yarn test run`
