### PR TITLE
refactor(vite-plugin-ssg): rename html tag utilities

### DIFF
--- a/packages/@wroud/vite-plugin-ssg/src/ssgPlugin.ts
+++ b/packages/@wroud/vite-plugin-ssg/src/ssgPlugin.ts
@@ -18,7 +18,7 @@ import {
 } from "./modules/mainQuery.js";
 import { addQueryParam, parseQueryParams } from "./utils/queryParam.js";
 import { cleanSsgAssetId, isSsgAssetId } from "./modules/isSsgAssetId.js";
-import { isSSgHtmlTagsId } from "./utils/ssgHtmlTags.js";
+import { isSsgHtmlTagsId } from "./utils/ssgHtmlTags.js";
 import {
   createSsgPageUrlId,
   isSsgPageUrlId,
@@ -134,7 +134,7 @@ export const ssgPlugin = (
           if (
             isSsgClientEntryId(source) ||
             isSsgServerEntryId(source) ||
-            isSSgHtmlTagsId(source) ||
+            isSsgHtmlTagsId(source) ||
             (importer &&
               isMainId(source) &&
               (isSsgClientEntryId(importer) || isSsgServerEntryId(importer)))
@@ -440,7 +440,7 @@ export const ssgPlugin = (
             };
           }
 
-          if (isSSgHtmlTagsId(id)) {
+          if (isSsgHtmlTagsId(id)) {
             return {
               code: `export default __VITE_SSG_HTML_TAGS__;`,
               moduleType: "js",

--- a/packages/@wroud/vite-plugin-ssg/src/utils/ssgHtmlTags.ts
+++ b/packages/@wroud/vite-plugin-ssg/src/utils/ssgHtmlTags.ts
@@ -1,10 +1,10 @@
 import { trailingSeparatorRE } from "./trailingSeparatorRE.js";
 
 export const ssgRE = /(\?|&)ssg-html-tags(?:&|$)/;
-export function removeSSgHtmlTagsQuery(url: string): string {
+export function removeSsgHtmlTagsQuery(url: string): string {
   return url.replace(ssgRE, "$1").replace(trailingSeparatorRE, "");
 }
 
-export function isSSgHtmlTagsId(id: string) {
+export function isSsgHtmlTagsId(id: string) {
   return ssgRE.test(id);
 }


### PR DESCRIPTION
## Summary
- rename html tag utility functions and update imports

## Testing
- `yarn workspace @wroud/vite-plugin-ssg build`
- `yarn workspace @wroud/vite-plugin-ssg test run` *(fails: Couldn't find a script named "test")*