### PR TITLE
docs(di): fix indefinite article for service resolver

### DIFF
--- a/packages/docs/src/packages/di/api.md
+++ b/packages/docs/src/packages/di/api.md
@@ -30,7 +30,7 @@ The `ServiceContainerBuilder` class is used to register services and build the s
 
 - **`addSingleton<T>(service: SingleServiceType<T>, resolver: IServiceImplementationResolver<T>): this`**
 
-  - Registers a singleton service with an service resolver as implementation.
+  - Registers a singleton service with a service resolver as implementation.
 
 - **`addTransient<T>(service: SingleServiceImplementation<T>): this`**
 


### PR DESCRIPTION
## Summary
- fix indefinite article for `IServiceImplementationResolver`

## Testing
- `yarn workspace @wroud/docs build` *(fails: ENOTDIR not a directory)*
- `yarn workspace @wroud/docs test run` *(fails: Couldn't find a script named "test")*