### PR TITLE
feat(ci): add tag prefix config

### DIFF
--- a/packages/@wroud/ci/LICENSE
+++ b/packages/@wroud/ci/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Aleksei Potsetsuev (Wroud)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@wroud/ci/README.md
+++ b/packages/@wroud/ci/README.md
@@ -1,0 +1,99 @@
+# @wroud/ci
+
+A small CLI for automating releases based on conventional commits. It bumps versions, updates your changelog and publishes GitHub releases.
+
+> **Note**: This tool currently works only with Yarn.
+
+## Installation
+
+```sh
+yarn add -D @wroud/ci
+```
+
+## Configuration
+
+Create an optional `wroud.ci.config.js` in the project root:
+
+```js
+export default {
+  repository: "owner/repo",
+  tagPrefix: "v",
+};
+```
+
+`repository` is used to generate links in the changelog. If omitted, `GITHUB_REPOSITORY` or the `repository.url` field from `package.json` is used. `tagPrefix` sets the prefix for git tags. It can also be provided via the `TAG_PREFIX` environment variable or the `tagPrefix` field in `package.json`.
+
+## Commands
+
+### `release [path]`
+Bump version and update changelog.
+- `--prefix` tag prefix (defaults to configured prefix)
+- `--change-log-file` path to changelog file
+- `--dry-run` preview actions without writing files
+
+### `git-tag`
+Create git tag for current version.
+- `--prefix` tag prefix (defaults to configured prefix)
+- `--dry-run` preview actions
+
+### `release-github`
+Publish GitHub releases for new tags.
+- `--prefix` tag prefix (defaults to configured prefix)
+- `--dry-run` preview actions
+
+## Single Package Repository
+
+Add scripts to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "ci:release": "ci release --prefix v",
+    "ci:git-tag": "ci git-tag --prefix v",
+    "ci:release-github": "ci release-github --prefix v"
+  }
+}
+```
+
+## Workspace with Multiple Packages
+
+Run the commands for each package using `yarn workspaces foreach`:
+
+```sh
+yarn workspaces foreach -A --topological-dev run ci:release
+```
+
+## Example Workflow
+
+```yaml
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: npx @wroud/ci release-github --prefix v
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Changelog
+
+Changes are documented in the [CHANGELOG](./CHANGELOG.md).
+
+## License
+
+MIT

--- a/packages/@wroud/ci/README.md
+++ b/packages/@wroud/ci/README.md
@@ -1,14 +1,38 @@
 # @wroud/ci
 
+[![ESM-only package][package]][esm-info-url]
+[![NPM version][npm]][npm-url]
+
+<!-- [![Install size][size]][size-url] -->
+
+[package]: https://img.shields.io/badge/package-ESM--only-ffe536.svg
+[esm-info-url]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
+[npm]: https://img.shields.io/npm/v/@wroud/ci.svg
+[npm-url]: https://npmjs.com/package/@wroud/ci
+[size]: https://packagephobia.com/badge?p=@wroud/ci
+[size-url]: https://packagephobia.com/result?p=@wroud/ci
+
 A small CLI for automating releases based on conventional commits. It bumps versions, updates your changelog and publishes GitHub releases.
 
 > **Note**: This tool currently works only with Yarn.
 
 ## Installation
 
+Install via npm:
+
 ```sh
-yarn add -D @wroud/ci
+npm install @wroud/ci
 ```
+
+Install via yarn
+
+```sh
+yarn add @wroud/ci
+```
+
+## Documentation
+
+For detailed usage and API reference, visit the [documentation site](https://wroud.dev).
 
 ## Configuration
 
@@ -48,9 +72,9 @@ Add scripts to your `package.json`:
 ```json
 {
   "scripts": {
-    "ci:release": "ci release --prefix v",
-    "ci:git-tag": "ci git-tag --prefix v",
-    "ci:release-github": "ci release-github --prefix v"
+    "ci:release": "ci release",
+    "ci:git-tag": "ci git-tag",
+    "ci:release-github": "ci release-github"
   }
 }
 ```
@@ -85,15 +109,15 @@ jobs:
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn build
-      - run: npx @wroud/ci release-github --prefix v
+      - run: npx @wroud/ci release-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Changelog
 
-Changes are documented in the [CHANGELOG](./CHANGELOG.md).
+All notable changes to this project will be documented in the [CHANGELOG](./CHANGELOG.md) file.
 
 ## License
 
-MIT
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/packages/@wroud/ci/package.json
+++ b/packages/@wroud/ci/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@wroud/ci",
   "private": true,
+  "version": "0.0.0",
   "type": "module",
   "packageManager": "yarn@4.6.0",
+  "license": "MIT",
+  "author": "Wroud",
+  "homepage": "https://wroud.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Wroud/foundation",
+    "directory": "packages/@wroud/ci"
+  },
   "bin": "./lib/cli.js",
   "scripts": {
     "test": "tests-runner",
@@ -31,6 +40,7 @@
     "@types/semver": "^7",
     "@types/yargs": "^17",
     "@vitest/coverage-v8": "^2",
+    "@wroud/tests-runner": "workspace:*",
     "@wroud/tsconfig": "workspace:*",
     "concurrently": "^9",
     "memfs": "^4",

--- a/packages/@wroud/ci/package.json
+++ b/packages/@wroud/ci/package.json
@@ -33,6 +33,7 @@
     "@vitest/coverage-v8": "^2",
     "@wroud/tsconfig": "workspace:*",
     "concurrently": "^9",
+    "memfs": "^4",
     "rimraf": "^6",
     "typescript": "^5",
     "vitest": "^2"

--- a/packages/@wroud/ci/src/REPOSITORY.ts
+++ b/packages/@wroud/ci/src/REPOSITORY.ts
@@ -1,1 +1,0 @@
-export const REPOSITORY = "Wroud/foundation";

--- a/packages/@wroud/ci/src/cli.ts
+++ b/packages/@wroud/ci/src/cli.ts
@@ -4,6 +4,7 @@ import { hideBin } from "yargs/helpers";
 import { makeRelease } from "./makeRelease.js";
 import { createReleaseTag } from "./createReleaseTag.js";
 import { publishGithubRelease } from "./publishGithubRelease.js";
+import { getTagPrefix } from "./config.js";
 import { createActionAuth } from "@octokit/auth-action";
 
 await yargs(hideBin(process.argv))
@@ -34,7 +35,7 @@ await yargs(hideBin(process.argv))
     },
     async (argv) => {
       await makeRelease({
-        prefix: argv.prefix,
+        prefix: argv.prefix ?? (await getTagPrefix()),
         changeLogFile: argv.changeLogFile,
         dryRun: argv.dryRun,
         path: argv.path,
@@ -64,7 +65,7 @@ await yargs(hideBin(process.argv))
     },
     async (argv) => {
       await createReleaseTag({
-        prefix: argv.prefix,
+        prefix: argv.prefix ?? (await getTagPrefix()),
         dryRun: argv.dryRun,
       });
     },
@@ -107,7 +108,7 @@ await yargs(hideBin(process.argv))
         authStrategy,
         owner,
         repository,
-        prefix: argv.prefix,
+        prefix: argv.prefix ?? (await getTagPrefix()),
         dryRun,
       });
     },

--- a/packages/@wroud/ci/src/config.ts
+++ b/packages/@wroud/ci/src/config.ts
@@ -10,11 +10,7 @@ const CONFIG_FILE = "wroud.ci.config.js";
 
 export async function loadConfig(): Promise<ICIConfig> {
   try {
-    const configPath = path.resolve(process.cwd(), CONFIG_FILE);
-    const code = await readFile(configPath, "utf8");
-    const mod = await import(
-      `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`
-    );
+    const mod = await import(path.resolve(process.cwd(), CONFIG_FILE));
     return mod.default ?? mod;
   } catch {
     return {};

--- a/packages/@wroud/ci/src/config.ts
+++ b/packages/@wroud/ci/src/config.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+
+export interface ICIConfig {
+  repository?: string;
+  tagPrefix?: string;
+}
+
+const CONFIG_FILE = "wroud.ci.config.js";
+
+export async function loadConfig(): Promise<ICIConfig> {
+  try {
+    const configPath = path.resolve(process.cwd(), CONFIG_FILE);
+    const code = await readFile(configPath, "utf8");
+    const mod = await import(
+      `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`
+    );
+    return mod.default ?? mod;
+  } catch {
+    return {};
+  }
+}
+
+export async function getRepository(): Promise<string | undefined> {
+  if (process.env["GITHUB_REPOSITORY"]) {
+    return process.env["GITHUB_REPOSITORY"];
+  }
+
+  const config = await loadConfig();
+  if (config.repository) {
+    return config.repository;
+  }
+
+  try {
+    const pkgPath = path.resolve(process.cwd(), "package.json");
+    const pkgCode = await readFile(pkgPath, "utf8");
+    const pkg = JSON.parse(pkgCode);
+    const repo =
+      typeof pkg.repository === "string" ? pkg.repository : pkg.repository?.url;
+    if (typeof repo === "string") {
+      const match = repo.match(/github.com[/:](.+?)(?:\.git)?$/i);
+      if (match) {
+        return match[1];
+      }
+    }
+  } catch {}
+
+  return undefined;
+}
+
+export async function getTagPrefix(): Promise<string | undefined> {
+  if (process.env["TAG_PREFIX"]) {
+    return process.env["TAG_PREFIX"];
+  }
+
+  const config = await loadConfig();
+  if (config.tagPrefix) {
+    return config.tagPrefix;
+  }
+
+  try {
+    const pkgPath = path.resolve(process.cwd(), "package.json");
+    const pkgCode = await readFile(pkgPath, "utf8");
+    const pkg = JSON.parse(pkgCode);
+    if (typeof pkg.tagPrefix === "string") {
+      return pkg.tagPrefix;
+    }
+    if (typeof pkg.release?.tagPrefix === "string") {
+      return pkg.release.tagPrefix;
+    }
+  } catch {}
+
+  return undefined;
+}

--- a/packages/@wroud/ci/src/getRepository.test.ts
+++ b/packages/@wroud/ci/src/getRepository.test.ts
@@ -1,41 +1,61 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { writeFile } from "fs/promises";
-import { temporaryDirectory } from "tempy";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { fs, vol } from "memfs";
 import path from "path";
 import { getRepository } from "./config.js";
 
-const cwd = process.cwd();
+vi.mock("fs", () => fs);
+vi.mock("fs/promises", () => fs.promises);
 
-afterEach(() => {
-  process.chdir(cwd);
-  delete process.env["GITHUB_REPOSITORY"];
+let configMock = {};
+
+vi.doMock("/project/wroud.ci.config.js", () => {
+  return {
+    get default() {
+      return configMock;
+    },
+  };
 });
 
-describe("getRepository", () => {
+const CWD = path.normalize("/project");
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vol.reset();
+  cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(CWD);
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vol.reset();
+  cwdSpy.mockRestore();
+  delete process.env["GITHUB_REPOSITORY"];
+  vi.resetModules();
+  vi.clearAllMocks();
+  configMock = {};
+});
+
+describe.sequential("getRepository", () => {
   it("from env", async () => {
     process.env["GITHUB_REPOSITORY"] = "owner/env";
     expect(await getRepository()).toBe("owner/env");
   });
 
   it("from config", async () => {
-    const dir = temporaryDirectory();
-    await writeFile(
-      path.join(dir, "wroud.ci.config.js"),
-      "export default { repository: 'owner/config' };",
-    );
-    process.chdir(dir);
-
+    configMock = { repository: "owner/config" };
     expect(await getRepository()).toBe("owner/config");
   });
 
   it("from package.json", async () => {
-    const dir = temporaryDirectory();
-    await writeFile(
-      path.join(dir, "package.json"),
-      JSON.stringify({ repository: { url: "https://github.com/owner/pkg" } }),
+    vol.fromJSON(
+      {
+        "package.json": JSON.stringify({
+          repository: { url: "https://github.com/owner/pkg" },
+        }),
+      },
+      CWD,
     );
-    process.chdir(dir);
 
+    console.log("try");
     expect(await getRepository()).toBe("owner/pkg");
   });
 });

--- a/packages/@wroud/ci/src/getRepository.test.ts
+++ b/packages/@wroud/ci/src/getRepository.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFile } from "fs/promises";
+import { temporaryDirectory } from "tempy";
+import path from "path";
+import { getRepository } from "./config.js";
+
+const cwd = process.cwd();
+
+afterEach(() => {
+  process.chdir(cwd);
+  delete process.env["GITHUB_REPOSITORY"];
+});
+
+describe("getRepository", () => {
+  it("from env", async () => {
+    process.env["GITHUB_REPOSITORY"] = "owner/env";
+    expect(await getRepository()).toBe("owner/env");
+  });
+
+  it("from config", async () => {
+    const dir = temporaryDirectory();
+    await writeFile(
+      path.join(dir, "wroud.ci.config.js"),
+      "export default { repository: 'owner/config' };",
+    );
+    process.chdir(dir);
+
+    expect(await getRepository()).toBe("owner/config");
+  });
+
+  it("from package.json", async () => {
+    const dir = temporaryDirectory();
+    await writeFile(
+      path.join(dir, "package.json"),
+      JSON.stringify({ repository: { url: "https://github.com/owner/pkg" } }),
+    );
+    process.chdir(dir);
+
+    expect(await getRepository()).toBe("owner/pkg");
+  });
+});

--- a/packages/@wroud/ci/src/getTagPrefix.test.ts
+++ b/packages/@wroud/ci/src/getTagPrefix.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fs, vol } from "memfs";
+import path from "path";
+import { getTagPrefix } from "./config.js";
+
+vi.mock("fs", () => fs);
+vi.mock("fs/promises", () => fs.promises);
+
+const CWD = path.normalize("/project");
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vol.reset();
+  cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(CWD);
+});
+
+afterEach(() => {
+  vol.reset();
+  cwdSpy.mockRestore();
+  delete process.env["TAG_PREFIX"];
+  vi.resetModules();
+});
+
+describe("getTagPrefix", () => {
+  it("from env", async () => {
+    process.env["TAG_PREFIX"] = "v";
+    expect(await getTagPrefix()).toBe("v");
+  });
+
+  it("from config", async () => {
+    vol.fromJSON({ "wroud.ci.config.js": "export default { tagPrefix: 'v' };" }, CWD);
+    expect(await getTagPrefix()).toBe("v");
+  });
+
+  it("from package.json", async () => {
+    vol.fromJSON({ "package.json": JSON.stringify({ tagPrefix: "v" }) }, CWD);
+    expect(await getTagPrefix()).toBe("v");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4490,6 +4490,7 @@ __metadata:
     "@wroud/tsconfig": "workspace:*"
     concurrently: "npm:^9"
     execa: "npm:^9"
+    memfs: "npm:^4"
     rimraf: "npm:^6"
     semver: "npm:^7"
     tempy: "npm:^3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4487,6 +4487,7 @@ __metadata:
     "@wroud/conventional-commits-parser": "workspace:*"
     "@wroud/git": "workspace:*"
     "@wroud/github": "workspace:*"
+    "@wroud/tests-runner": "workspace:*"
     "@wroud/tsconfig": "workspace:*"
     concurrently: "npm:^9"
     execa: "npm:^9"


### PR DESCRIPTION
## Summary
- allow configuring a tag prefix for `@wroud/ci`
- resolve config and package.json paths with `node:path`
- document usage, configuration and workflow in the README
- add tests for `getTagPrefix`

## Testing
- `yarn workspace @wroud/ci run build --verbose`
- `yarn test run -t getTagPrefix`
- `yarn test run -t getRepository`
