### PR TITLE
docs: expand navigation docs

### DIFF
--- a/packages/docs/.vitepress/data/sidebar.ts
+++ b/packages/docs/.vitepress/data/sidebar.ts
@@ -120,6 +120,16 @@ export const sidebar: DefaultTheme.Sidebar = {
               },
             ],
           },
+          {
+            text: "Navigation",
+            base: "/packages/navigation/",
+            items: [
+              { text: "Overview", link: "overview" },
+              { text: "Installation", link: "install" },
+              { text: "Usage", link: "usage" },
+              { text: "API", link: "api" },
+            ],
+          },
         ],
       },
     ],

--- a/packages/docs/src/packages/navigation/api.md
+++ b/packages/docs/src/packages/navigation/api.md
@@ -1,0 +1,42 @@
+---
+outline: deep
+---
+
+# API
+
+This section summarizes the main classes exported by `@wroud/navigation`.
+For complete type information, see the bundled TypeScript declarations.
+
+## Navigation
+
+Manages the current route state and history.
+
+### Methods
+
+- `navigate(state: IRouteState): Promise<void>` – navigate to a route state.
+- `replace(state: IRouteState): Promise<void>` – replace the current state.
+- `goBack(): Promise<void>` – go back in history.
+- `addListener(fn)` – subscribe to navigation events.
+
+## Router
+
+Defines and matches application routes.
+
+### Methods
+
+- `addRoute(route: IRoute)`: register a new route definition.
+- `matchUrl(url: string): IRouteState | null`: match a URL to a route.
+- `buildUrl(id: string, params?): string`: build a URL from an id and params.
+
+## BrowserNavigation
+
+Synchronizes navigation with the browser's URL and history.
+
+### Methods
+
+- `registerRoutes(): Promise<void>` – start listening to browser events and restore initial state.
+- `dispose(): void` – remove listeners and clean up.
+
+## Pattern Matching
+
+`TriePatternMatching` provides the default implementation used by `Router` for flexible route patterns.

--- a/packages/docs/src/packages/navigation/install.md
+++ b/packages/docs/src/packages/navigation/install.md
@@ -1,0 +1,29 @@
+---
+outline: deep
+---
+
+# Installation
+
+<Badges name="@wroud/navigation" />
+
+Install with your package manager of choice:
+
+::: code-group
+
+```sh [npm]
+npm install @wroud/navigation
+```
+
+```sh [yarn]
+yarn add @wroud/navigation
+```
+
+```sh [pnpm]
+pnpm add @wroud/navigation
+```
+
+```sh [bun]
+bun add @wroud/navigation
+```
+
+:::

--- a/packages/docs/src/packages/navigation/overview.md
+++ b/packages/docs/src/packages/navigation/overview.md
@@ -1,0 +1,17 @@
+---
+outline: deep
+---
+
+# Navigation
+
+`@wroud/navigation` is a flexible, pattern-matching navigation system for JavaScript applications. It works in any framework and provides powerful pattern matching, browser integration and navigation state management.
+
+## Key Features
+
+- **Pattern-based Routing**: Define static routes, parameter segments (`/users/:id`) and wildcards (`/files/:path*`).
+- **Framework Agnostic**: Compatible with any JavaScript framework or vanilla JS.
+- **Type Safety**: Written in TypeScript with full inference for route parameters.
+- **Navigation History**: Built-in history management.
+- **Browser Integration**: Optional synchronization with the browser's URL.
+- **Extensible**: Build custom navigation implementations for any environment.
+- **Pure ESM**: Ships as an ES module for modern tooling.

--- a/packages/docs/src/packages/navigation/usage.md
+++ b/packages/docs/src/packages/navigation/usage.md
@@ -1,0 +1,56 @@
+---
+outline: deep
+---
+
+# Usage
+
+This section demonstrates how to configure routing and perform navigation.
+
+## Basic Usage
+
+```ts
+import { Navigation, Router } from "@wroud/navigation";
+
+const router = new Router();
+router.addRoute({ id: "/" });
+router.addRoute({ id: "/users/:id" });
+
+const navigation = new Navigation(router);
+await navigation.navigate({ id: "/users/:id", params: { id: "123" } });
+```
+
+## Browser Integration
+
+```ts
+import { Navigation, Router, TriePatternMatching } from "@wroud/navigation";
+import { BrowserNavigation } from "@wroud/navigation/browser";
+
+const router = new Router({
+  matcher: new TriePatternMatching({ trailingSlash: true, base: "/app" }),
+});
+router.addRoute({ id: "/" });
+router.addRoute({ id: "/products/:id" });
+
+const navigation = new Navigation(router);
+const browserNavigation = new BrowserNavigation(navigation);
+await browserNavigation.registerRoutes();
+```
+
+## Navigation Guards
+
+```ts
+import { Navigation, Router } from "@wroud/navigation";
+
+const router = new Router();
+router.addRoute({ id: "/" });
+router.addRoute({
+  id: "/dashboard",
+  canActivate: () => isAuthenticated(),
+});
+router.addRoute({
+  id: "/editor/:documentId",
+  canDeactivate: () => confirm("Discard unsaved changes?"),
+});
+
+const navigation = new Navigation(router);
+```

--- a/packages/docs/src/packages/overview.md
+++ b/packages/docs/src/packages/overview.md
@@ -9,6 +9,7 @@ The Wroud Foundation offers a suite of tools to help developers implement best p
 ## Available Packages
 
 - **@wroud/di**: A lightweight dependency injection library for JavaScript inspired by [.NET's DI](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) system. Written in TypeScript, it supports modern JavaScript features, including decorators, and provides robust dependency management capabilities.
+- **@wroud/navigation**: Framework-agnostic router and navigation utilities with pattern-based matching, history management and optional browser integration.
 
 - **Other Packages**: More tools to come, each aimed at addressing specific challenges in JavaScript development.
 
@@ -22,6 +23,13 @@ Use the sidebar to navigate through the documentation. Each package has its own 
 - **[Installation](./di/install)**: Step-by-step guide to installing the package.
 - **[Usage](./di/usage)**: Examples of how to use the package in different environments.
 - **[API](./di/api)**: Detailed reference of the API provided by the package.
+
+## Navigation (`@wroud/navigation`)
+
+- **[Overview](./navigation/overview)**: Introduction and key features.
+- **[Installation](./navigation/install)**: How to install the package.
+- **[Usage](./navigation/usage)**: Basic usage example.
+- **[API](./navigation/api)**: Summary of the main exports.
 
 ### React Integration (`@wroud/di-react`)
 


### PR DESCRIPTION
## Summary
- flesh out Navigation docs to remove README references
- add browser integration example, navigation guards, and API details

## Testing
- `yarn workspace @wroud/docs build` *(fails: ENOTDIR: not a directory, stat '/workspace/foundation/packages/docs/node_modules/vue')*
- `yarn workspace @wroud/docs test run` *(fails: Couldn't find a script named "test")*