### PR TITLE
docs(preconditions): add package documentation

### DIFF
--- a/packages/docs/.vitepress/data/sidebar.ts
+++ b/packages/docs/.vitepress/data/sidebar.ts
@@ -120,6 +120,15 @@ export const sidebar: DefaultTheme.Sidebar = {
               },
             ],
           },
+          {
+            text: "Preconditions",
+            base: "/packages/preconditions/",
+            items: [
+              { text: "Overview", link: "overview" },
+              { text: "Installation", link: "install" },
+              { text: "Usage", link: "usage" },
+            ],
+          },
         ],
       },
     ],

--- a/packages/docs/src/guide/index.md
+++ b/packages/docs/src/guide/index.md
@@ -21,6 +21,12 @@ Explore the tools available for analyzing and visualizing your dependency graph.
 - [DI Tools](/guide/package/di-tools/)
 - [@wroud/di-tools-analyzer](/guide/package/di-tools/analyzer/introduction)
 
+#### Preconditions
+
+Manage complex loading requirements using the `@wroud/preconditions` package.
+
+- [@wroud/preconditions](/packages/preconditions/overview)
+
 ## Getting Started
 
 If you're new to Wroud Foundation, we recommend starting with the Dependency Injection (DI) guide. It provides a comprehensive overview of the `@wroud/di` package's capabilities and how to integrate it into your projects.

--- a/packages/docs/src/packages/overview.md
+++ b/packages/docs/src/packages/overview.md
@@ -9,6 +9,7 @@ The Wroud Foundation offers a suite of tools to help developers implement best p
 ## Available Packages
 
 - **@wroud/di**: A lightweight dependency injection library for JavaScript inspired by [.NET's DI](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) system. Written in TypeScript, it supports modern JavaScript features, including decorators, and provides robust dependency management capabilities.
+- **@wroud/preconditions**: Manage entity preconditions with dynamic applicability and fulfillment logic.
 
 - **Other Packages**: More tools to come, each aimed at addressing specific challenges in JavaScript development.
 
@@ -29,6 +30,12 @@ Use the sidebar to navigate through the documentation. Each package has its own 
 - **[Installation](./di/integrations/react/install)**: Step-by-step guide to setting it up in your React application.
 - **[Usage](./di/integrations/react/usage)**: Practical examples and patterns for using it within React components.
 - **[API](./di/integrations/react/api)**: Complete API reference.
+
+## Preconditions (`@wroud/preconditions`)
+
+- **[Overview](./preconditions/overview)**: Introduction and key features.
+- **[Installation](./preconditions/install)**: Step-by-step guide to installing the package.
+- **[Usage](./preconditions/usage)**: Example of defining and applying preconditions.
 
 ## Future Tools
 

--- a/packages/docs/src/packages/preconditions/install.md
+++ b/packages/docs/src/packages/preconditions/install.md
@@ -1,0 +1,29 @@
+---
+outline: deep
+---
+
+# Installation
+
+<Badges name="@wroud/preconditions" />
+
+Install with npm, or use your favorite package manager:
+
+::: code-group
+
+```sh [npm]
+npm install @wroud/preconditions
+```
+
+```sh [yarn]
+yarn add @wroud/preconditions
+```
+
+```sh [pnpm]
+pnpm add @wroud/preconditions
+```
+
+```sh [bun]
+bun add @wroud/preconditions
+```
+
+:::

--- a/packages/docs/src/packages/preconditions/overview.md
+++ b/packages/docs/src/packages/preconditions/overview.md
@@ -1,0 +1,44 @@
+---
+outline: deep
+---
+
+# Preconditions
+
+`@wroud/preconditions` is a flexible library for defining and managing preconditions for your entities. It helps you validate and prepare data by registering preconditions that can be checked or fulfilled dynamically.
+
+## Key Features
+
+- **Entity-Specific Managers**: Manage preconditions for different entity types independently.
+- **Dynamic Applicability**: Apply preconditions only when they are relevant to the current entity.
+- **Extensibility**: Register additional preconditions in a plugin-style manner.
+- **Check and Fulfill**: Validate preconditions or attempt to fulfill them automatically.
+- **TypeScript Support**: Written in TypeScript for strong typing.
+- **Pure ESM** package.
+
+## Basic Usage
+
+```ts
+import { PreconditionManager, type IPrecondition } from "@wroud/preconditions";
+
+interface Node {
+  id: string;
+  data: { requiresDatabaseConnection?: boolean };
+}
+
+class DatabaseConnectionPrecondition implements IPrecondition<Node> {
+  isApplicable(node: Node): boolean {
+    return node.data.requiresDatabaseConnection === true;
+  }
+
+  async check(node: Node): Promise<boolean> {
+    return databaseConnection.isEstablished();
+  }
+
+  async fulfill(node: Node): Promise<void> {
+    await databaseConnection.connect();
+  }
+}
+
+const manager = new PreconditionManager<Node>();
+manager.register(new DatabaseConnectionPrecondition());
+```

--- a/packages/docs/src/packages/preconditions/usage.md
+++ b/packages/docs/src/packages/preconditions/usage.md
@@ -1,0 +1,51 @@
+---
+outline: deep
+---
+
+# Usage
+
+This example demonstrates how to define and fulfill preconditions for an entity.
+
+```ts
+import { PreconditionManager, type IPrecondition } from "@wroud/preconditions";
+
+interface Node {
+  id: string;
+  data: { requiresDatabaseConnection?: boolean };
+}
+
+class DatabaseConnectionPrecondition implements IPrecondition<Node> {
+  isApplicable(node: Node): boolean {
+    return node.data.requiresDatabaseConnection === true;
+  }
+
+  async check(node: Node): Promise<boolean> {
+    return databaseConnection.isEstablished();
+  }
+
+  async fulfill(node: Node): Promise<void> {
+    await databaseConnection.connect();
+  }
+}
+
+const nodePreconditionManager = new PreconditionManager<Node>();
+nodePreconditionManager.register(new DatabaseConnectionPrecondition());
+
+const node: Node = {
+  id: "node1",
+  data: { requiresDatabaseConnection: true },
+};
+
+const canLoad = await nodePreconditionManager.checkPreconditions(node);
+
+if (canLoad) {
+  console.log("Node can be loaded.");
+} else {
+  try {
+    await nodePreconditionManager.fulfillPreconditions(node);
+    console.log("Preconditions fulfilled. Node is ready to load.");
+  } catch (error) {
+    console.error("Failed to fulfill preconditions:", error);
+  }
+}
+```


### PR DESCRIPTION
## Summary
- document `@wroud/preconditions`
- list package in docs overview and sidebar
- mention in guide index
- expand usage example with fulfillment logic

## Testing
- `yarn workspace @wroud/docs build` *(fails: ENOTDIR)*
- `yarn workspace @wroud/docs test run` *(fails: Couldn't find a script)*
- `yarn workspace @wroud/preconditions build`
- `yarn workspace @wroud/preconditions test run` *(fails: Couldn't find a script)*