### PR TITLE
docs: expand react split view docs

### DIFF
--- a/packages/docs/src/packages/overview.md
+++ b/packages/docs/src/packages/overview.md
@@ -10,6 +10,8 @@ The Wroud Foundation offers a suite of tools to help developers implement best p
 
 - **@wroud/di**: A lightweight dependency injection library for JavaScript inspired by [.NET's DI](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) system. Written in TypeScript, it supports modern JavaScript features, including decorators, and provides robust dependency management capabilities.
 
+- **@wroud/react-split-view**: A React hook for building resizable split panes with optional sticky edges.
+
 - **Other Packages**: More tools to come, each aimed at addressing specific challenges in JavaScript development.
 
 # Navigation
@@ -29,6 +31,13 @@ Use the sidebar to navigate through the documentation. Each package has its own 
 - **[Installation](./di/integrations/react/install)**: Step-by-step guide to setting it up in your React application.
 - **[Usage](./di/integrations/react/usage)**: Practical examples and patterns for using it within React components.
 - **[API](./di/integrations/react/api)**: Complete API reference.
+
+## React Split View (`@wroud/react-split-view`)
+
+- **[Overview](./react-split-view/overview)**: Introduction and key features.
+- **[Installation](./react-split-view/install)**: Steps to add it to your project.
+- **[Usage](./react-split-view/usage)**: Examples for horizontal and vertical splits.
+- **[API](./react-split-view/api)**: Complete API reference.
 
 ## Future Tools
 

--- a/packages/docs/src/packages/react-split-view/api.md
+++ b/packages/docs/src/packages/react-split-view/api.md
@@ -1,0 +1,29 @@
+---
+outline: deep
+---
+
+# API
+
+## useSplitView
+
+```ts
+function useSplitView<T extends HTMLElement>(options?: {
+  sticky?: number;
+}): {
+  viewProps: React.HTMLAttributes<T>;
+  sashProps: React.HTMLAttributes<HTMLElement>;
+};
+```
+
+`useSplitView` is part of a pure ESM package and provides typed helpers for managing split panes.
+
+### Options
+
+| Option   | Type   | Description                                                |
+| -------- | ------ | ---------------------------------------------------------- |
+| `sticky` | number | Distance in pixels from the edge where the sash will snap. |
+
+### Return Value
+
+- `viewProps` – props to spread on the resizable element.
+- `sashProps` – props to spread on the divider element for drag handling.

--- a/packages/docs/src/packages/react-split-view/install.md
+++ b/packages/docs/src/packages/react-split-view/install.md
@@ -1,0 +1,50 @@
+---
+outline: deep
+---
+
+# Installation
+
+<Badges name="@wroud/react-split-view" />
+
+Install with your favorite package manager, or check [CDN Usage](#cdn-usage) for other options:
+
+::: code-group
+
+```sh [npm]
+npm install @wroud/react-split-view
+```
+
+```sh [yarn]
+yarn add @wroud/react-split-view
+```
+
+```sh [pnpm]
+pnpm add @wroud/react-split-view
+```
+
+```sh [bun]
+bun add @wroud/react-split-view
+```
+
+:::
+
+### CJS Usage
+
+`@wroud/react-split-view` is an ESM-only package. To use it in a CommonJS environment, dynamically import the module:
+
+```ts
+async function main() {
+  const { useSplitView } = await import("@wroud/react-split-view");
+  // ...
+}
+```
+
+### CDN Usage
+
+For browser usage without bundling, load the module from [esm.sh](https://esm.sh) or [esm.run](https://esm.run):
+
+```html
+<script type="module">
+  import { useSplitView } from "https://esm.sh/@wroud/react-split-view@1.0.0";
+</script>
+```

--- a/packages/docs/src/packages/react-split-view/overview.md
+++ b/packages/docs/src/packages/react-split-view/overview.md
@@ -1,0 +1,17 @@
+---
+outline: deep
+---
+
+# React Split View
+
+## Overview
+
+`@wroud/react-split-view` is a lightweight React hook for creating resizable split panes. It supports horizontal and vertical layouts with minimal configuration and no external dependencies.
+
+## Key Features
+
+- **Simple API**: Manage split views with a single hook.
+- **Lightweight**: Small bundle size and zero dependencies.
+- **Flexible Layouts**: Horizontal, vertical, and nested splits.
+- **Sticky Edges**: Optional snap-to-edge behavior while dragging.
+- **TypeScript**: Written in TypeScript for a fully typed API.

--- a/packages/docs/src/packages/react-split-view/usage.md
+++ b/packages/docs/src/packages/react-split-view/usage.md
@@ -1,0 +1,103 @@
+---
+outline: deep
+---
+
+# Usage
+
+The `useSplitView` hook provides everything needed to create resizable split panes. It returns props that can be spread on your elements to enable drag-to-resize functionality.
+
+## Horizontal Split (default)
+
+```tsx
+import { useSplitView } from "@wroud/react-split-view";
+
+function Example() {
+  const split = useSplitView<HTMLDivElement>();
+  return (
+    <div className="container">
+      <div {...split.viewProps} className="panel">
+        Left
+      </div>
+      <div {...split.sashProps} className="sash" />
+      <div className="panel">Right</div>
+    </div>
+  );
+}
+```
+
+Required CSS:
+
+```css
+.container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.panel {
+  flex: 1;
+  overflow: auto;
+}
+
+.sash {
+  width: 4px;
+  background-color: #ccc;
+  cursor: ew-resize;
+}
+```
+
+## Vertical Split
+
+```tsx
+function Vertical() {
+  const split = useSplitView<HTMLDivElement>();
+  return (
+    <div className="container" style={{ flexDirection: "column" }}>
+      <div {...split.viewProps} className="panel">
+        Top
+      </div>
+      <div {...split.sashProps} className="sash" />
+      <div className="panel">Bottom</div>
+    </div>
+  );
+}
+```
+
+## Advanced Features
+
+### Sticky Edges
+
+Enable snapping when the sash is near the container edge.
+
+```tsx
+const split = useSplitView<HTMLDivElement>({
+  sticky: 20, // pixels from the edge
+});
+```
+
+### Multiple Splits
+
+```tsx
+function MultipleSplits() {
+  const first = useSplitView<HTMLDivElement>();
+  const second = useSplitView<HTMLDivElement>();
+
+  return (
+    <div className="container">
+      <div {...first.viewProps} className="panel">
+        Left
+      </div>
+      <div {...first.sashProps} className="sash" />
+      <div className="panel">
+        <div className="container" style={{ flexDirection: "column" }}>
+          <div {...second.viewProps} className="panel">
+            Top Right
+          </div>
+          <div {...second.sashProps} className="sash" />
+          <div className="panel">Bottom Right</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```


### PR DESCRIPTION
## Summary
- enrich `@wroud/react-split-view` docs with more details
- document installation options and advanced usage

## Testing
- `yarn workspace @wroud/docs build` *(fails: ENOTDIR stat '/workspace/foundation/packages/docs/node_modules/vue')*
- `yarn workspace @wroud/docs test run` *(fails: Couldn't find a script named "test")*