### PR TITLE
docs: add vite asset resolver docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Wroud Foundation provides tools to help developers implement best practices 
 ### Available Packages
 
 - **@wroud/di**: A lightweight dependency injection library for JavaScript inspired by [.NET's DI](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) system. Written in TypeScript, it supports modern JavaScript features, including decorators, and provides robust dependency management capabilities.
+- **@wroud/vite-plugin-asset-resolver**: A Vite plugin that maps compiled asset paths back to source directories for custom resolution.
 
 ### Future Tools
 

--- a/packages/docs/src/guide/index.md
+++ b/packages/docs/src/guide/index.md
@@ -21,6 +21,12 @@ Explore the tools available for analyzing and visualizing your dependency graph.
 - [DI Tools](/guide/package/di-tools/)
 - [@wroud/di-tools-analyzer](/guide/package/di-tools/analyzer/introduction)
 
+### Vite Plugins
+
+Enhance your Vite workflow with dedicated plugins.
+
+- [@wroud/vite-plugin-asset-resolver](/guide/package/vite-plugin-asset-resolver/)
+
 ## Getting Started
 
 If you're new to Wroud Foundation, we recommend starting with the Dependency Injection (DI) guide. It provides a comprehensive overview of the `@wroud/di` package's capabilities and how to integrate it into your projects.

--- a/packages/docs/src/guide/package/vite-plugin-asset-resolver/index.md
+++ b/packages/docs/src/guide/package/vite-plugin-asset-resolver/index.md
@@ -1,0 +1,12 @@
+---
+outline: deep
+---
+
+# Asset Resolver Plugin
+
+The `@wroud/vite-plugin-asset-resolver` plugin helps Vite locate assets in your source directories even when your compiled output lives elsewhere.
+
+- [Overview](/packages/vite-plugin-asset-resolver/overview)
+- [Installation](/packages/vite-plugin-asset-resolver/install)
+- [Usage](/packages/vite-plugin-asset-resolver/usage)
+- [API](/packages/vite-plugin-asset-resolver/api)

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -16,6 +16,9 @@ hero:
     - theme: alt
       text: "@wroud/di-react"
       link: packages/di/integrations/react/overview
+    - theme: alt
+      text: "@wroud/vite-plugin-asset-resolver"
+      link: /packages/vite-plugin-asset-resolver/overview
   image:
     src: /icon-big.svg
     alt: Wroud Foundation

--- a/packages/docs/src/packages/overview.md
+++ b/packages/docs/src/packages/overview.md
@@ -9,6 +9,7 @@ The Wroud Foundation offers a suite of tools to help developers implement best p
 ## Available Packages
 
 - **@wroud/di**: A lightweight dependency injection library for JavaScript inspired by [.NET's DI](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) system. Written in TypeScript, it supports modern JavaScript features, including decorators, and provides robust dependency management capabilities.
+- **@wroud/vite-plugin-asset-resolver**: A Vite plugin that resolves assets from source directories when your compiled files live elsewhere.
 
 - **Other Packages**: More tools to come, each aimed at addressing specific challenges in JavaScript development.
 
@@ -29,6 +30,13 @@ Use the sidebar to navigate through the documentation. Each package has its own 
 - **[Installation](./di/integrations/react/install)**: Step-by-step guide to setting it up in your React application.
 - **[Usage](./di/integrations/react/usage)**: Practical examples and patterns for using it within React components.
 - **[API](./di/integrations/react/api)**: Complete API reference.
+
+## Asset Resolver (`@wroud/vite-plugin-asset-resolver`)
+
+- **[Overview](./vite-plugin-asset-resolver/overview)**: Introduction and key features.
+- **[Installation](./vite-plugin-asset-resolver/install)**: How to install the plugin.
+- **[Usage](./vite-plugin-asset-resolver/usage)**: Example configuration.
+- **[API](./vite-plugin-asset-resolver/api)**: Reference for available options.
 
 ## Future Tools
 

--- a/packages/docs/src/packages/vite-plugin-asset-resolver/api.md
+++ b/packages/docs/src/packages/vite-plugin-asset-resolver/api.md
@@ -1,0 +1,19 @@
+---
+outline: deep
+---
+
+# API
+
+## `assetResolverPlugin(options?: IResolveAssetsOptions)`
+
+Creates the Vite plugin instance.
+
+### Options
+
+- **`dist`** – array of compiled asset directories. Defaults to `["dist", "lib", "build", "out", "output"]`.
+- **`src`** – array of source directories. Defaults to `["src", "source", "app", "assets"]`.
+- **`extensions`** – array of file extensions to resolve. Defaults to a set of common asset extensions.
+
+### Constants
+
+The package also exports `DEFAULT_DIST`, `DEFAULT_SRC`, and `KNOWN_ASSET_TYPES`.

--- a/packages/docs/src/packages/vite-plugin-asset-resolver/install.md
+++ b/packages/docs/src/packages/vite-plugin-asset-resolver/install.md
@@ -1,0 +1,29 @@
+---
+outline: deep
+---
+
+# Installation
+
+<Badges name="@wroud/vite-plugin-asset-resolver" />
+
+Install with your favorite package manager:
+
+::: code-group
+
+```sh [npm]
+npm install @wroud/vite-plugin-asset-resolver
+```
+
+```sh [yarn]
+yarn add @wroud/vite-plugin-asset-resolver
+```
+
+```sh [pnpm]
+pnpm add @wroud/vite-plugin-asset-resolver
+```
+
+```sh [bun]
+bun add @wroud/vite-plugin-asset-resolver
+```
+
+:::

--- a/packages/docs/src/packages/vite-plugin-asset-resolver/overview.md
+++ b/packages/docs/src/packages/vite-plugin-asset-resolver/overview.md
@@ -1,0 +1,13 @@
+---
+outline: deep
+---
+
+# Asset Resolver Plugin
+
+`@wroud/vite-plugin-asset-resolver` is a Vite plugin that remaps asset imports from `dist` directories to `src` directories. This helps maintain cleaner imports when your project structure separates compiled files from source files.
+
+## Features
+
+- **Custom Asset Resolution**: Resolve images, SVGs, and other assets from `src` instead of `dist`.
+- **Multiple Aliases**: Define multiple `src` and `dist` directories.
+- **Custom Extensions**: Specify which file extensions to resolve.

--- a/packages/docs/src/packages/vite-plugin-asset-resolver/usage.md
+++ b/packages/docs/src/packages/vite-plugin-asset-resolver/usage.md
@@ -1,0 +1,22 @@
+---
+outline: deep
+---
+
+# Usage
+
+Below is a basic example showing how to configure the plugin in your Vite setup.
+
+```ts
+import { defineConfig } from "vite";
+import { assetResolverPlugin } from "@wroud/vite-plugin-asset-resolver";
+
+export default defineConfig({
+  plugins: [
+    assetResolverPlugin({
+      dist: ["dist", "build"],
+      src: ["src", "source"],
+      extensions: [".svg", ".png", ".jpg"],
+    }),
+  ],
+});
+```


### PR DESCRIPTION
## Summary
- document `@wroud/vite-plugin-asset-resolver` usage and API
- link the asset resolver docs from the home page

## Testing
- `yarn workspace @wroud/docs build` *(fails: project doesn't seem installed)*