### PR TITLE
docs: add react-split-view sidebar

### DIFF
--- a/packages/docs/.vitepress/data/sidebar.ts
+++ b/packages/docs/.vitepress/data/sidebar.ts
@@ -129,6 +129,16 @@ export const sidebar: DefaultTheme.Sidebar = {
               { text: "Usage", link: "usage" },
             ],
           },
+          {
+            text: "React Split View",
+            base: "/packages/react-split-view/",
+            items: [
+              { text: "Overview", link: "overview" },
+              { text: "Installation", link: "install" },
+              { text: "Usage", link: "usage" },
+              { text: "API", link: "api" },
+            ],
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- update sidebar config to include React Split View section

## Testing
- `yarn workspace @wroud/docs build` *(fails: ENOTDIR: not a directory, stat '/workspace/foundation/packages/docs/node_modules/vue')*
- `yarn workspace @wroud/docs test run` *(fails: Couldn't find a script named "test")*