### PR TITLE
docs: add react tree documentation

### DIFF
--- a/packages/docs/.vitepress/data/sidebar.ts
+++ b/packages/docs/.vitepress/data/sidebar.ts
@@ -139,6 +139,16 @@ export const sidebar: DefaultTheme.Sidebar = {
               { text: "API", link: "api" },
             ],
           },
+          {
+            text: "React Tree",
+            base: "/packages/react-tree/",
+            items: [
+              { text: "Overview", link: "overview" },
+              { text: "Installation", link: "install" },
+              { text: "Usage", link: "usage" },
+              { text: "API", link: "api" },
+            ],
+          },
         ],
       },
     ],

--- a/packages/docs/src/packages/overview.md
+++ b/packages/docs/src/packages/overview.md
@@ -12,6 +12,7 @@ The Wroud Foundation offers a suite of tools to help developers implement best p
 - **@wroud/vite-plugin-tsc**: A Vite plugin that runs the TypeScript compiler to transpile project references and perform background type checking.
 
 - **@wroud/react-split-view**: A React hook for building resizable split panes with optional sticky edges.
+- **@wroud/react-tree**: A virtualized tree component for React.
 
 - **Other Packages**: More tools to come, each aimed at addressing specific challenges in JavaScript development.
 
@@ -39,6 +40,13 @@ Use the sidebar to navigate through the documentation. Each package has its own 
 - **[Installation](./react-split-view/install)**: Steps to add it to your project.
 - **[Usage](./react-split-view/usage)**: Examples for horizontal and vertical splits.
 - **[API](./react-split-view/api)**: Complete API reference.
+
+## React Tree (`@wroud/react-tree`)
+
+- **[Overview](./react-tree/overview)**: Introduction and key features.
+- **[Installation](./react-tree/install)**: Steps to add it to your project.
+- **[Usage](./react-tree/usage)**: Examples of basic setup and lazy loading.
+- **[API](./react-tree/api)**: Complete API reference.
 
 ## Future Tools
 

--- a/packages/docs/src/packages/react-tree/api.md
+++ b/packages/docs/src/packages/react-tree/api.md
@@ -1,0 +1,40 @@
+---
+outline: deep
+---
+
+# API
+
+This page lists the main exports from `@wroud/react-tree`. See the source code for detailed comments (e.g., the `ITree` interface).
+
+## Components
+
+- **`Tree`** – top-level component that provides contexts and renders nodes.
+- **`Node`** – renders a single tree node.
+- **`NodeChildren`** – virtualized renderer for a node's children.
+- **`TreeNodeControl`**, **`TreeNodeExpand`**, **`TreeNodeIcon`**, **`TreeNodeName`** – building blocks for custom node UIs.
+
+## Hooks
+
+- **`useTree`** – creates a tree controller implementing `ITree`.
+- **`useNodeSizeCache`** – caches node heights for virtualization.
+- **`useTreeViewport`** – tracks the visible range of the tree.
+
+## Contexts
+
+- **`TreeContext`**, **`TreeDataContext`**, **`NodeSizeCacheContext`**, **`TreeVirtualizationContext`**, **`TreeClassesContext`** – provide state and styling information.
+
+## Utilities
+
+- **`treeClasses`**, **`getCombinedClasses`** – default CSS classes and merging helper.
+
+## Types
+
+- `ITree`, `ITreeProps`, `ITreeData`
+- `INode`, `INodeState`
+- `NodeComponent`, `NodeComponentProps`
+- `INodeSizeCache`, `IViewPort`, `ITreeVirtualization`, `UseTreeViewportResult`
+- `ITreeClasses`
+
+## Internals
+
+- `NodeControl` and `NodeRenderer` are exported for reference when implementing custom nodes.

--- a/packages/docs/src/packages/react-tree/install.md
+++ b/packages/docs/src/packages/react-tree/install.md
@@ -1,0 +1,49 @@
+---
+outline: deep
+---
+
+# Installation
+
+<Badges name="@wroud/react-tree" />
+
+Install with your favorite package manager, or check [CDN Usage](#cdn-usage) for other options:
+
+::: code-group
+
+```sh [npm]
+npm install @wroud/react-tree
+```
+
+```sh [yarn]
+yarn add @wroud/react-tree
+```
+
+```sh [pnpm]
+pnpm add @wroud/react-tree
+```
+
+```sh [bun]
+bun add @wroud/react-tree
+```
+
+:::
+
+### CJS Usage
+
+`@wroud/react-tree` is ESM-only. To use it from CommonJS, dynamically import the module:
+
+```ts
+async function main() {
+  const { Tree } = await import("@wroud/react-tree");
+}
+```
+
+### CDN Usage
+
+For quick demos in the browser, load the module from [esm.sh](https://esm.sh) or [esm.run](https://esm.run):
+
+```html
+<script type="module">
+  import { Tree } from "https://esm.sh/@wroud/react-tree@1.0.0";
+</script>
+```

--- a/packages/docs/src/packages/react-tree/overview.md
+++ b/packages/docs/src/packages/react-tree/overview.md
@@ -1,0 +1,15 @@
+---
+outline: deep
+---
+
+# React Tree
+
+`@wroud/react-tree` is a virtualized tree component for React. It focuses on performance and customization so you can efficiently render large hierarchies.
+
+## Key Features
+
+- **Virtualization** for rendering only the visible portion of large trees.
+- **Node Selection** built in through the `useTree` hook.
+- **Custom Renderers** to override node controls or content.
+- **Async Loading** support for fetching children on demand.
+- **CSS Customization** via class maps and optional default styles.

--- a/packages/docs/src/packages/react-tree/usage.md
+++ b/packages/docs/src/packages/react-tree/usage.md
@@ -1,0 +1,84 @@
+---
+outline: deep
+---
+
+# Usage
+
+This example shows a basic tree setup using the `useTree` hook and the `Tree` component. Node height is stored in a reactive value so virtualization can calculate offsets.
+
+```tsx
+import { Tree, useTree } from "@wroud/react-tree";
+import { useCreateReactiveValue } from "@wroud/react-reactive-value";
+
+const data = {
+  rootId: "root",
+  getNode(id: string) {
+    return { name: id === "root" ? "Root" : `Node ${id}` };
+  },
+  getChildren(id: string) {
+    return id === "root" ? ["a", "b", "c"] : [];
+  },
+  getState() {
+    return { expanded: true, selected: false };
+  },
+  updateState() {},
+  updateStateAll() {},
+};
+
+function App() {
+  const nodeHeight = useCreateReactiveValue(() => 24, null, []);
+  const tree = useTree({ data });
+
+  return (
+    <div style={{ height: 300 }}>
+      <Tree tree={tree} nodeHeight={nodeHeight} />
+    </div>
+  );
+}
+```
+
+### Custom Control Renderer
+
+You can override how each node is displayed by providing a `controlRenderer`.
+
+```tsx
+import {
+  TreeNodeControl,
+  TreeNodeExpand,
+  TreeNodeName,
+} from "@wroud/react-tree";
+
+function CustomControl({ nodeId }) {
+  return (
+    <TreeNodeControl>
+      <TreeNodeExpand />
+      <TreeNodeName>{`Custom ${nodeId}`}</TreeNodeName>
+    </TreeNodeControl>
+  );
+}
+
+<Tree tree={tree} nodeHeight={nodeHeight} controlRenderer={CustomControl} />;
+```
+
+### Lazy Loading
+
+`getChildren` can return a promise so nodes load as needed:
+
+```ts
+const tree = useTree({
+  data: {
+    rootId: "root",
+    async getChildren(id) {
+      return fetchChildren(id);
+    },
+    getNode() {
+      return { name: "" };
+    },
+    getState() {
+      return { expanded: false, selected: false };
+    },
+    updateState() {},
+    updateStateAll() {},
+  },
+});
+```


### PR DESCRIPTION
## Summary
- document `@wroud/react-tree` and add docs section in overview
- update sidebar navigation for the new package

## Testing
- `yarn workspace @wroud/docs build` *(fails: cannot find module @wroud/di during docs build)*
- `yarn workspace @wroud/docs test run` *(fails: script not found)*