### PR TITLE
feat(parser): include body as breaking change with bang

### DIFF
--- a/packages/@wroud/conventional-commits-changelog/__snapshots__/createConventionalChangelog.test.js.snap
+++ b/packages/@wroud/conventional-commits-changelog/__snapshots__/createConventionalChangelog.test.js.snap
@@ -62,7 +62,6 @@ exports[`createConventionalChangelog > default 1`] = `
   "- test commit with something (1dfaff1)",
   "  - Some breaky change",
   "- disable auto release (5a84e8d)",
-  "  - disable auto release",
   "- release @wroud/di@0.9.1 (cde6098)",
   "  - Some breaky change",
   "",
@@ -79,6 +78,18 @@ exports[`createConventionalChangelog > default 1`] = `
   "- collect jest statistic for provided package (f98f7b1)",
   "- add installation section (6fb62f9)",
   "- add dependency injection overview page (fc9ef0f)",
+  "",
+]
+`;
+
+exports[`createConventionalChangelog > skip duplicate breaking change 1`] = `
+[
+  "<!-- changelog -->",
+  "### ⚠️  Breaking Changes",
+  "",
+  "- change (1111111)",
+  "- new api (2222222)",
+  "  - breaking details",
   "",
 ]
 `;
@@ -145,7 +156,6 @@ exports[`createConventionalChangelog > with metadata co-authors 1`] = `
   "- test commit with something (1dfaff1)",
   "  - Some breaky change",
   "- disable auto release (5a84e8d)",
-  "  - disable auto release",
   "- release @wroud/di@0.9.1 (cde6098)",
   "  - Some breaky change",
   "",
@@ -236,7 +246,6 @@ exports[`createConventionalChangelog > with metadata formatter 1`] = `
   "- (1dfaff1) test commit with something (1dfaff1)",
   "  - (1dfaff1) Some breaky change",
   "- (5a84e8d) disable auto release (5a84e8d)",
-  "  - (5a84e8d) disable auto release",
   "- (cde6098) release @wroud/di@0.9.1 (cde6098)",
   "  - (cde6098) Some breaky change",
   "",
@@ -319,7 +328,6 @@ exports[`createConventionalChangelog > with metadata url 1`] = `
   "- test commit with something ([1dfaff1](https://example.com/1dfaff1))",
   "  - Some breaky change",
   "- disable auto release ([5a84e8d](https://example.com/5a84e8d))",
-  "  - disable auto release",
   "- release @wroud/di@0.9.1 ([cde6098](https://example.com/cde6098))",
   "  - Some breaky change",
   "",

--- a/packages/@wroud/conventional-commits-changelog/src/createConventionalChangelog.test.ts
+++ b/packages/@wroud/conventional-commits-changelog/src/createConventionalChangelog.test.ts
@@ -127,4 +127,49 @@ describe("createConventionalChangelog", () => {
 
     expect(changelog).toMatchSnapshot();
   });
+
+  it("skip duplicate breaking change", async () => {
+    const commitNoBody: IConventionalCommit = {
+      commitInfo: {
+        hash: "1111111",
+        tags: [],
+        authorName: "Tester",
+        authorEmail: "tester@example.com",
+        subject: "feat!: change",
+        body: "",
+        trailers: [],
+        links: {},
+      },
+      type: "feat",
+      description: "change",
+      breakingChanges: ["change"],
+    };
+
+    const commitWithBody: IConventionalCommit = {
+      commitInfo: {
+        hash: "2222222",
+        tags: [],
+        authorName: "Tester",
+        authorEmail: "tester@example.com",
+        subject: "feat!: new api",
+        body: "breaking details\n",
+        trailers: [],
+        links: {},
+      },
+      type: "feat",
+      description: "new api",
+      body: "breaking details",
+      breakingChanges: ["breaking details"],
+    };
+
+    const changelog: string[] = [];
+    for await (const line of createConventionalChangelog([
+      commitNoBody,
+      commitWithBody,
+    ])) {
+      changelog.push(line);
+    }
+
+    expect(changelog).toMatchSnapshot();
+  });
 });

--- a/packages/@wroud/conventional-commits-changelog/src/createConventionalChangelog.ts
+++ b/packages/@wroud/conventional-commits-changelog/src/createConventionalChangelog.ts
@@ -142,6 +142,9 @@ function* createChangesList(
     yield message;
 
     for (const breakingChange of commit.breakingChanges) {
+      if (!commit.body && breakingChange === commit.description) {
+        continue;
+      }
       const lines = formatMessage(
         commit.metadata?.formatter
           ? commit.metadata.formatter(breakingChange)

--- a/packages/@wroud/conventional-commits-parser/__snapshots__/parseConventionalCommit.test.js.snap
+++ b/packages/@wroud/conventional-commits-parser/__snapshots__/parseConventionalCommit.test.js.snap
@@ -1,5 +1,28 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`parseConventionalCommit > breaking body 1`] = `
+{
+  "body": "This change breaks things",
+  "breakingChanges": [
+    "This change breaks things",
+  ],
+  "commitInfo": {
+    "authorEmail": "tester@example.com",
+    "authorName": "Tester",
+    "body": "This change breaks things
+",
+    "hash": "abcdef1",
+    "links": {},
+    "subject": "feat!: changed API",
+    "tags": [],
+    "trailers": [],
+  },
+  "description": "changed API",
+  "scope": undefined,
+  "type": "feat",
+}
+`;
+
 exports[`parseConventionalCommit > without 1`] = `
 [
   {

--- a/packages/@wroud/conventional-commits-parser/src/parseConventionalCommit.test.ts
+++ b/packages/@wroud/conventional-commits-parser/src/parseConventionalCommit.test.ts
@@ -15,4 +15,19 @@ describe("parseConventionalCommit", () => {
     const commits = JSON.parse(data);
     expect(commits.map(parseConventionalCommit)).toMatchSnapshot();
   });
+
+  it("breaking body", () => {
+    const commit = {
+      hash: "abcdef1",
+      tags: [],
+      authorName: "Tester",
+      authorEmail: "tester@example.com",
+      subject: "feat!: changed API",
+      body: "This change breaks things\n",
+      trailers: [],
+      links: {},
+    };
+
+    expect(parseConventionalCommit(commit)).toMatchSnapshot();
+  });
 });

--- a/packages/@wroud/conventional-commits-parser/src/parseConventionalCommit.ts
+++ b/packages/@wroud/conventional-commits-parser/src/parseConventionalCommit.ts
@@ -20,8 +20,14 @@ export function parseConventionalCommit(
     description: string;
   };
 
+  const rawBody = commitInfo.body?.trim() || "";
+
   if (breaking) {
-    breakingChanges.push(description);
+    if (rawBody) {
+      breakingChanges.push(rawBody);
+    } else {
+      breakingChanges.push(description);
+    }
   }
 
   for (const trailer of commitInfo.trailers) {
@@ -36,7 +42,9 @@ export function parseConventionalCommit(
     }
   }
 
-  const body = commitInfo.body?.trim() || undefined;
+  const body = rawBody || undefined;
+
+  const uniqueBreakingChanges = Array.from(new Set(breakingChanges));
 
   return {
     commitInfo,
@@ -44,6 +52,6 @@ export function parseConventionalCommit(
     scope: scope || undefined,
     description,
     body,
-    breakingChanges,
+    breakingChanges: uniqueBreakingChanges,
   };
 }


### PR DESCRIPTION
## Summary
- include commit body as breaking change when header has `!`
- dedupe breaking change entries
- avoid duplicate breaking change details in changelog
- test coverage for parser and changelog updates

## Testing
- `yarn workspace @wroud/conventional-commits-parser run build`
- `yarn workspace @wroud/conventional-commits-parser run test run -u`
- `yarn workspace @wroud/conventional-commits-changelog run build`
- `yarn workspace @wroud/conventional-commits-changelog run test run -u`


------
https://chatgpt.com/codex/tasks/task_e_684115d2441c8332bc129b01fbb0b3c6