### PR TITLE
docs: link package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,33 @@ The Wroud Foundation provides tools to help developers implement best practices 
 
 The following packages are available on npm:
 
-- **@wroud/api-logger**: Lightweight logging interface for JavaScript and TypeScript applications.
-- **@wroud/ci**: Automate releases via conventional commits and GitHub Actions.
-- **@wroud/conventional-commits-bump**: Determine semantic version bumps from commit messages.
-- **@wroud/conventional-commits-changelog**: Generate markdown changelogs from conventional commits.
-- **@wroud/conventional-commits-parser**: Parse conventional commit messages with metadata support.
-- **@wroud/di**: Simple dependency injection library for JavaScript and TypeScript.
-- **@wroud/di-react**: React bindings for the @wroud/di library.
-- **@wroud/di-tools-analyzer**: Analyze @wroud/di containers and visualize dependencies.
-- **@wroud/di-tools-codemod**: Codemod for migrating from Inversify to @wroud/di.
-- **@wroud/flow-middleware**: Manage middleware chains with re-runs and error handling.
-- **@wroud/git**: Utilities for reading commits and tags from git repositories.
-- **@wroud/github**: Parse git history for GitHub issues and commit links.
-- **@wroud/navigation**: Framework-agnostic navigation and routing system.
-- **@wroud/playground**: Core runtime for the component playground system.
-- **@wroud/playground-react**: React components for interactive playground stories.
-- **@wroud/preconditions**: Framework for defining and applying preconditions.
-- **@wroud/react-reactive-value**: Manage reactive values in React with automatic re-renders.
-- **@wroud/react-split-view**: React hook for resizable split views.
-- **@wroud/react-tree**: Virtualized tree component for hierarchical data.
-- **@wroud/ts-project-linker**: Sync TypeScript project references with package dependencies.
-- **@wroud/ts-template**: CLI generator for TypeScript project templates.
-- **@wroud/vite-plugin-asset-resolver**: Custom asset resolution plugin for Vite.
-- **@wroud/vite-plugin-playground**: Vite plugin for component playground stories.
-- **@wroud/vite-plugin-ssg**: Static site generation plugin for React with Vite.
-- **@wroud/vite-plugin-tsc**: Transpile TypeScript using tsc during Vite builds.
-- **graphql-codegen-fragment-masking**: GraphQL Codegen plugin for fragment masking helpers.
-- **graphql-codegen-typed-document-nodes**: GraphQL Codegen plugin for typed document nodes.
+- [**@wroud/api-logger**](packages/@wroud/api-logger): Lightweight logging interface for JavaScript and TypeScript applications.
+- [**@wroud/ci**](packages/@wroud/ci): Automate releases via conventional commits and GitHub Actions.
+- [**@wroud/conventional-commits-bump**](packages/@wroud/conventional-commits-bump): Determine semantic version bumps from commit messages.
+- [**@wroud/conventional-commits-changelog**](packages/@wroud/conventional-commits-changelog): Generate markdown changelogs from conventional commits.
+- [**@wroud/conventional-commits-parser**](packages/@wroud/conventional-commits-parser): Parse conventional commit messages with metadata support.
+- [**@wroud/di**](packages/@wroud/di): Simple dependency injection library for JavaScript and TypeScript.
+- [**@wroud/di-react**](packages/@wroud/di-react): React bindings for the @wroud/di library.
+- [**@wroud/di-tools-analyzer**](packages/@wroud/di-tools-analyzer): Analyze @wroud/di containers and visualize dependencies.
+- [**@wroud/di-tools-codemod**](packages/@wroud/di-tools-codemod): Codemod for migrating from Inversify to @wroud/di.
+- [**@wroud/flow-middleware**](packages/@wroud/flow-middleware): Manage middleware chains with re-runs and error handling.
+- [**@wroud/git**](packages/@wroud/git): Utilities for reading commits and tags from git repositories.
+- [**@wroud/github**](packages/@wroud/github): Parse git history for GitHub issues and commit links.
+- [**@wroud/navigation**](packages/@wroud/navigation): Framework-agnostic navigation and routing system.
+- [**@wroud/playground**](packages/@wroud/playground): Core runtime for the component playground system.
+- [**@wroud/playground-react**](packages/@wroud/playground-react): React components for interactive playground stories.
+- [**@wroud/preconditions**](packages/@wroud/preconditions): Framework for defining and applying preconditions.
+- [**@wroud/react-reactive-value**](packages/@wroud/react-reactive-value): Manage reactive values in React with automatic re-renders.
+- [**@wroud/react-split-view**](packages/@wroud/react-split-view): React hook for resizable split views.
+- [**@wroud/react-tree**](packages/@wroud/react-tree): Virtualized tree component for hierarchical data.
+- [**@wroud/ts-project-linker**](packages/@wroud/ts-project-linker): Sync TypeScript project references with package dependencies.
+- [**@wroud/ts-template**](packages/@wroud/ts-template): CLI generator for TypeScript project templates.
+- [**@wroud/vite-plugin-asset-resolver**](packages/@wroud/vite-plugin-asset-resolver): Custom asset resolution plugin for Vite.
+- [**@wroud/vite-plugin-playground**](packages/@wroud/vite-plugin-playground): Vite plugin for component playground stories.
+- [**@wroud/vite-plugin-ssg**](packages/@wroud/vite-plugin-ssg): Static site generation plugin for React with Vite.
+- [**@wroud/vite-plugin-tsc**](packages/@wroud/vite-plugin-tsc): Transpile TypeScript using tsc during Vite builds.
+- [**graphql-codegen-fragment-masking**](packages/graphql-codegen-fragment-masking): GraphQL Codegen plugin for fragment masking helpers.
+- [**graphql-codegen-typed-document-nodes**](packages/graphql-codegen-typed-document-nodes): GraphQL Codegen plugin for typed document nodes.
 
 ### Future Tools
 


### PR DESCRIPTION
## Summary
- link package names in root README to their respective directories

## Testing
- `yarn build`
- `yarn test run`


------
https://chatgpt.com/codex/tasks/task_e_688e5696342c833285a8bd4951705655