### PR TITLE
docs: refine vite-plugin-tsc docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following packages are available on npm:
 - [**@wroud/vite-plugin-asset-resolver**](packages/@wroud/vite-plugin-asset-resolver): Custom asset resolution plugin for Vite.
 - [**@wroud/vite-plugin-playground**](packages/@wroud/vite-plugin-playground): Vite plugin for component playground stories.
 - [**@wroud/vite-plugin-ssg**](packages/@wroud/vite-plugin-ssg): Static site generation plugin for React with Vite.
-- [**@wroud/vite-plugin-tsc**](packages/@wroud/vite-plugin-tsc): Transpile TypeScript using tsc during Vite builds.
+- [**@wroud/vite-plugin-tsc**](packages/@wroud/vite-plugin-tsc): Integrate `tsc` with Vite for background type checking or transpile TypeScript files with project reference support.
 - [**graphql-codegen-fragment-masking**](packages/graphql-codegen-fragment-masking): GraphQL Codegen plugin for fragment masking helpers.
 - [**graphql-codegen-typed-document-nodes**](packages/graphql-codegen-typed-document-nodes): GraphQL Codegen plugin for typed document nodes.
 

--- a/packages/@wroud/vite-plugin-tsc/README.md
+++ b/packages/@wroud/vite-plugin-tsc/README.md
@@ -8,11 +8,17 @@
 [npm]: https://img.shields.io/npm/v/@wroud/vite-plugin-tsc.svg
 [npm-url]: https://npmjs.com/package/@wroud/vite-plugin-tsc
 
-`@wroud/vite-plugin-tsc` is a Vite plugin designed to transpile TypeScript and its project references using the TypeScript compiler (`tsc`). This plugin allows Vite to seamlessly bundle the transpiled code while also providing background type checking for your project, ensuring type safety and enhancing the development workflow.
+`@wroud/vite-plugin-tsc` brings the TypeScript compiler (`tsc`) to Vite. Vite's default esbuild pipeline skips type checking, so this plugin can run `tsc` to surface type errors during development or builds. It can also transpile TypeScript files that Vite then bundles, keeping all Vite features intact. The plugin supports TypeScript project references.
+
+## Use Cases
+
+- **Type checking**: Run `tsc` in the background to catch type errors that esbuild ignores.
+- **Transpilation**: Transpile TypeScript files with `tsc` and let Vite bundle the output.
 
 ## Features
 
 - **Transpilation**: Automatically transpiles TypeScript code using `tsc`.
+- **Project References**: Supports TypeScript project references.
 - **Background Type Checking**: Performs type checking in the background without blocking Vite, allowing for a smoother development experience.
 - **Watch Mode**: Supports watch mode for continuous development.
 - **Easy Integration**: Simple to add to your Vite project.

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -43,7 +43,7 @@ features:
     details: Get started quickly without needing extensive knowledge, thanks to straightforward and intuitive design.
   - icon: ⚙️
     title: TypeScript Build Support
-    details: Use the TypeScript compiler with Vite via `@wroud/vite-plugin-tsc`.
+    details: Bring `tsc` to Vite for type checking or transpiling TypeScript files via `@wroud/vite-plugin-tsc`.
     link: /packages/vite-plugin-tsc/overview
     linkText: See documentation
 ---

--- a/packages/docs/src/packages/overview.md
+++ b/packages/docs/src/packages/overview.md
@@ -9,7 +9,7 @@ The Wroud Foundation offers a suite of tools to help developers implement best p
 ## Available Packages
 
 - **@wroud/di**: A lightweight dependency injection library for JavaScript inspired by [.NET's DI](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) system. Written in TypeScript, it supports modern JavaScript features, including decorators, and provides robust dependency management capabilities.
-- **@wroud/vite-plugin-tsc**: A Vite plugin that runs the TypeScript compiler to transpile project references and perform background type checking.
+- **@wroud/vite-plugin-tsc**: Run `tsc` with Vite to check types that esbuild misses or transpile TypeScript files while keeping Vite features.
 
 - **@wroud/react-split-view**: A React hook for building resizable split panes with optional sticky edges.
 - **@wroud/react-tree**: A virtualized tree component for React.

--- a/packages/docs/src/packages/vite-plugin-tsc/overview.md
+++ b/packages/docs/src/packages/vite-plugin-tsc/overview.md
@@ -4,11 +4,17 @@ outline: deep
 
 # Vite Plugin TSC
 
-`@wroud/vite-plugin-tsc` allows you to use the TypeScript compiler (`tsc`) within Vite. It transpiles project references and provides background type checking so you can keep using Vite's fast bundling while ensuring type safety.
+`@wroud/vite-plugin-tsc` brings the TypeScript compiler (`tsc`) to Vite. Because Vite relies on esbuild for speed, TypeScript errors are not checked by default. This plugin can run `tsc` to surface type errors during development or builds and can also transpile TypeScript files, allowing Vite to be configured to consume those files without losing any of its features. It also supports TypeScript project references.
+
+## Use Cases
+
+- **Type checking**: Run `tsc` alongside Vite's dev server to report type errors that esbuild ignores.
+- **Transpilation**: Transpile TypeScript files using `tsc`, then let Vite consume the generated files.
 
 ## Key Features
 
-- **Transpilation**: Uses `tsc` to transpile TypeScript and project references.
+- **Transpilation**: Uses `tsc` to transpile TypeScript files.
+- **Project references**: Supports TypeScript project references.
 - **Background type checking**: Runs `tsc` in watch mode to surface type errors without blocking the Vite dev server.
 - **Prebuild support**: Optionally builds dependencies before Vite starts.
 - **Watch mode**: Automatically recompiles when files change.
@@ -23,10 +29,11 @@ import { defineConfig } from "vite";
 import { tscPlugin } from "@wroud/vite-plugin-tsc";
 
 export default defineConfig({
+  root: "dist", // folder defined as tsc outDir
   plugins: [
     tscPlugin({
       tscArgs: ["-b"],
-      prebuild: true,
+      prebuild: true, // recommended for TypeScript project references
     }),
   ],
 });

--- a/packages/docs/src/packages/vite-plugin-tsc/usage.md
+++ b/packages/docs/src/packages/vite-plugin-tsc/usage.md
@@ -4,18 +4,27 @@ outline: deep
 
 # Usage
 
-Import the plugin and add it to your Vite configuration. Use `tscArgs` to pass arguments to the TypeScript compiler and enable `prebuild` if you rely on project references.
+The plugin supports two main scenarios: transpiling TypeScript or just checking types. In both cases, import the plugin and add it to your Vite configuration. Use `tscArgs` to pass arguments to the TypeScript compiler and enable `prebuild` if you rely on project references.
+
+## Transpilation
+
+Use `tsc` to emit JavaScript that Vite will bundle. Point Vite at the emitted files so all of its features continue to work:
 
 ```ts
 import { defineConfig } from "vite";
 import { tscPlugin } from "@wroud/vite-plugin-tsc";
 
 export default defineConfig({
-  plugins: [tscPlugin({ tscArgs: ["-b"], prebuild: true })],
+  root: "dist", // folder defined as tsc outDir
+  plugins: [
+    tscPlugin({ tscArgs: ["-b"], prebuild: true }), // prebuild is useful for project references
+  ],
 });
 ```
 
-For type checking only, disable `prebuild`:
+## Type Checking
+
+Run `tsc` in watch mode without emitting files to surface type errors while keeping esbuild's output:
 
 ```ts
 import { defineConfig } from "vite";


### PR DESCRIPTION
## Summary
- simplify vite-plugin-tsc wording to "transpile TypeScript files"
- document TypeScript project reference support and show Vite pointing at tsc output
- restore installation guide to its previous content

## Testing
- `yarn build`
- `yarn workspace @wroud/vite-plugin-tsc test run --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68923891e2908332b7e3defc16caad68